### PR TITLE
fix: buildEndpointUrl remove too much when trimming line item URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.4.1
+-----
+
+* Fixed buildEndpointUrl of ScoreServiceClient when trimming line item URL provided by AGS claims
+
 0.4.0
 -----
 

--- a/src/Service/Score/Client/ScoreServiceClient.php
+++ b/src/Service/Score/Client/ScoreServiceClient.php
@@ -131,7 +131,11 @@ class ScoreServiceClient implements ScoreServiceInterface
         $parsedUrl = parse_url($lineItemUrl);
 
         $parsedUrl['path'] = rtrim($parsedUrl['path'], '/');
-        $parsedUrl['path'] = rtrim($parsedUrl['path'], '/lineitem');
+        $endStringToRemove = '/lineitem';
+
+        if (str_ends_with($parsedUrl['path'], $endStringToRemove)) {
+            $parsedUrl['path'] = substr($parsedUrl['path'], 0, -1 * strlen($endStringToRemove));
+        }
 
         $username = $parsedUrl['user'] ?? '';
         $password = isset($parsedUrl['pass']) ? ':' . $parsedUrl['pass']  : '';


### PR DESCRIPTION
[TR-890](https://oat-sa.atlassian.net/browse/TR-890)

The goal of this PR is to fix the excessive trim done on the line item URL to build the /score endpoint URL