### PR TITLE
fix: unlock the core library dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "nesbot/carbon": "^2.72 || ^3.0",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "7.2.2",
+        "oat-sa/lib-lti1p3-core": "^7.0",
         "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR fixes dependency mishap introduced in https://github.com/oat-sa/lib-lti1p3-ags/pull/65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to allow for a broader range of compatible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->