### PR TITLE
ResultService: fix resolving lineItemIdentifier from request URI

### DIFF
--- a/src/Service/Result/Server/Handler/ResultServiceServerRequestHandler.php
+++ b/src/Service/Result/Server/Handler/ResultServiceServerRequestHandler.php
@@ -115,8 +115,9 @@ class ResultServiceServerRequestHandler implements LtiServiceServerRequestHandle
         ServerRequestInterface $request,
         array $options = []
     ): ResponseInterface {
-        $lineItemIdentifier = current(
-            explode('?', $this->extractor->extract($request->getUri()->__toString(), 'results'))
+        $lineItemIdentifier = $this->extractor->extract(
+            $request->getUri()->__toString(), 
+            'results'
         );
 
         $lineItem = $this->lineItemRepository->find($lineItemIdentifier);

--- a/src/Service/Result/Server/Handler/ResultServiceServerRequestHandler.php
+++ b/src/Service/Result/Server/Handler/ResultServiceServerRequestHandler.php
@@ -115,10 +115,7 @@ class ResultServiceServerRequestHandler implements LtiServiceServerRequestHandle
         ServerRequestInterface $request,
         array $options = []
     ): ResponseInterface {
-        $lineItemIdentifier = $this->extractor->extract(
-            $request->getUri()->__toString(), 
-            'results'
-        );
+        $lineItemIdentifier = $this->extractor->extract($request->getUri()->__toString(), 'results');
 
         $lineItem = $this->lineItemRepository->find($lineItemIdentifier);
 


### PR DESCRIPTION
See issue detail [here](https://github.com/oat-sa/lib-lti1p3-ags/issues/67)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified how request identifiers are obtained during result handling to streamline internal processing; no user-facing behavior or error handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->